### PR TITLE
Fix compilation warning

### DIFF
--- a/ESP_Messenger_v1.0
+++ b/ESP_Messenger_v1.0
@@ -230,7 +230,7 @@ static void sendStr(unsigned char *string)
 //==========================================================//
 // Prints a string in coordinates X Y, being multiples of 8.
 // This means we have 16 COLS (0-15) and 8 ROWS (0-7).
-static void sendStrXY( char *string, int X, int Y)
+static void sendStrXY(const char *string, int X, int Y)
 {
   setXY(X,Y);
   unsigned char i=0;


### PR DESCRIPTION
Compiler was warning
warning: deprecated conversion from string constant to ‘char*’
[-Wwrite-strings]
Changed signature and it was fixed.
